### PR TITLE
feat: added status error format option

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,23 @@ err.toPayload();
 */
 ```
 
+**Customize your errors as much as you want**
+
+You can select options like: the error code, adding status to the body of your Error, etc.
+
+```js
+class InvalidUser extends UnicaError('INVALID_USER', UnicaError.InvalidArgument, true) {}
+let err = new InvalidUser("The user is not valid");
+err.toPayload();
+/*
+{
+  "code": "INVALID_USER",
+  "message": "The user is not valid",
+  "status": 400
+}
+*/
+```
+
 ## Peer Projects
 * [therror](https://github.com/therror/therror): The Error utility
 * [therror-connect](https://github.com/therror/therror-connect): Connect/Express error handler

--- a/lib/index.js
+++ b/lib/index.js
@@ -19,7 +19,7 @@
 
 const Therror = require('therror');
 
-function UnicaError(code, Base, isCamara=false) {
+function UnicaError(code, Base, includeStatus=false) {
   return class extends Base {
     constructor(cause, msg, props) {
       super(cause, msg, props);
@@ -35,7 +35,7 @@ function UnicaError(code, Base, isCamara=false) {
         message: this.getPayloadMessage(),
       };
 
-      if (isCamara) {
+      if (includeStatus) {
         payload.status = this.statusCode;
       }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -19,7 +19,7 @@
 
 const Therror = require('therror');
 
-function UnicaError(code, Base) {
+function UnicaError(code, Base, isCamara=false) {
   return class extends Base {
     constructor(cause, msg, props) {
       super(cause, msg, props);
@@ -28,11 +28,18 @@ function UnicaError(code, Base) {
     }
 
     // Overried the toPayload method in the ServerError to return the UNICA payload
+    // Also if the error format is CAMARA, add the status property
     toPayload() {
-      return {
+      const payload = {
         code: this.unicaCode,
         message: this.getPayloadMessage(),
       };
+
+      if (isCamara) {
+        payload.status = this.statusCode;
+      }
+
+      return payload;
     }
   };
 }

--- a/test/unica.spec.js
+++ b/test/unica.spec.js
@@ -149,5 +149,28 @@ describe('UnicaError Errors', function() {
       expect(err.unicaCode).to.be.equals('TIMEOUT');
       expect(err.statusCode).to.be.equals(504);
     });
+
+    it('Erros with CAMARA format should have the status property in body', function(){
+      class Foo extends UnicaError('ERROR_CODE', UnicaError.InvalidArgument, true) {}
+
+      let err = new Foo();
+
+      expect(err.toPayload().status).to.be.eql(400);
+    });
+
+    it('Erros with no CAMARA format should not have the status property in body', function(){
+      class Foo extends UnicaError('ERROR_CODE', UnicaError.InvalidArgument, false) {}
+
+      let err = new Foo();
+
+      expect(err.toPayload().status).to.be.eql(undefined);
+
+      class Foo2 extends UnicaError('ERROR_CODE', UnicaError.InvalidArgument) {}
+
+      err = new Foo2();
+
+      expect(err.toPayload().status).to.be.eql(undefined);
+    });
+
   });
 });

--- a/test/unica.spec.js
+++ b/test/unica.spec.js
@@ -150,7 +150,7 @@ describe('UnicaError Errors', function() {
       expect(err.statusCode).to.be.equals(504);
     });
 
-    it('Erros with CAMARA format should have the status property in body', function(){
+    it('Erros with status format should have the status property in body', function(){
       class Foo extends UnicaError('ERROR_CODE', UnicaError.InvalidArgument, true) {}
 
       let err = new Foo();
@@ -158,7 +158,7 @@ describe('UnicaError Errors', function() {
       expect(err.toPayload().status).to.be.eql(400);
     });
 
-    it('Erros with no CAMARA format should not have the status property in body', function(){
+    it('Erros with no status format should not have the status property in body', function(){
       class Foo extends UnicaError('ERROR_CODE', UnicaError.InvalidArgument, false) {}
 
       let err = new Foo();


### PR DESCRIPTION
A flag is added, for error handling in format defined by [CAMARA project](https://github.com/camaraproject) standards. As these in the HTTP response through the body, in addition to `code` and `message`, the `status` property is specified with the HTTP status code of the error.